### PR TITLE
fixes last item flickering while dragging

### DIFF
--- a/lib/drag_and_drop_list.dart
+++ b/lib/drag_and_drop_list.dart
@@ -304,7 +304,7 @@ class _DragAndDropListState<T> extends State<DragAndDropList> {
     });
 
     if (_currentIndex >= rows.length) {
-      _currentIndex--;
+      return;
     }
 
     setState(() {


### PR DESCRIPTION
Hello! 

Just after start dragging the last item, the previous one moves to its place which creates a "hole" in the list. A simple `return` when the `_currentIndex` doesn't add up should fix it.

Thank you!