### PR TITLE
Refresh list when state is changed from FutureBuilder

### DIFF
--- a/lib/drag_and_drop_list.dart
+++ b/lib/drag_and_drop_list.dart
@@ -106,6 +106,12 @@ class _DragAndDropListState<T> extends State<DragAndDropList> {
   @override
   void initState() {
     super.initState();
+    populateRowList();
+  }
+
+  void populateRowList() {
+    List data = widget.rowsData;
+    rows = data.map((it) => new Data<T>(it)).toList();
   }
 
   void _maybeScroll() {
@@ -142,8 +148,7 @@ class _DragAndDropListState<T> extends State<DragAndDropList> {
   @override
   void didUpdateWidget(DragAndDropList<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    List data = widget.rowsData;
-    rows = data.map((it) => new Data<T>(it)).toList();
+    populateRowList();
   }
 
   @override

--- a/lib/drag_and_drop_list.dart
+++ b/lib/drag_and_drop_list.dart
@@ -106,12 +106,14 @@ class _DragAndDropListState<T> extends State<DragAndDropList> {
   @override
   void initState() {
     super.initState();
-    List data = widget.rowsData;
-    rows = data.map((it) => new Data<T>(it)).toList();
-
+    updateRows();
   }
 
-
+  void updateRows() {
+    List data = widget.rowsData;
+    rows = data.map((it) => new Data<T>(it)).toList();
+  }
+  
   void _maybeScroll() {
     if (isScrolling) return;
 
@@ -145,6 +147,11 @@ class _DragAndDropListState<T> extends State<DragAndDropList> {
 
   @override
   Widget build(BuildContext context) {
+    // update the list of rows passed to the widget unless the user is currently dragging a row
+    if (widget.rowsData.length != rows.length && _currentDraggingIndex == null) {
+        updateRows();
+    }
+
     return new LayoutBuilder(
       builder: (BuildContext context3, constr) {
         return new ListView.builder(

--- a/lib/drag_and_drop_list.dart
+++ b/lib/drag_and_drop_list.dart
@@ -106,14 +106,8 @@ class _DragAndDropListState<T> extends State<DragAndDropList> {
   @override
   void initState() {
     super.initState();
-    updateRows();
   }
 
-  void updateRows() {
-    List data = widget.rowsData;
-    rows = data.map((it) => new Data<T>(it)).toList();
-  }
-  
   void _maybeScroll() {
     if (isScrolling) return;
 
@@ -146,12 +140,14 @@ class _DragAndDropListState<T> extends State<DragAndDropList> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    // update the list of rows passed to the widget unless the user is currently dragging a row
-    if (widget.rowsData.length != rows.length && _currentDraggingIndex == null) {
-        updateRows();
-    }
+  void didUpdateWidget(DragAndDropList<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    List data = widget.rowsData;
+    rows = data.map((it) => new Data<T>(it)).toList();
+  }
 
+  @override
+  Widget build(BuildContext context) {
     return new LayoutBuilder(
       builder: (BuildContext context3, constr) {
         return new ListView.builder(


### PR DESCRIPTION
This change allows the parent Widget to update state and have the snapshot data reload the list if it is a different size. It compares the `widget.rowsData` to the local `rows` and updates `rows` **IF** the user isn't currently dragging (since dragging alters the number of rows while being dragged).