### PR TITLE
Bumped SDK max version to < 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.1.4
 
 
 environment:
-  sdk: ">=1.19.0 <2.0.0"
+  sdk: ">=1.19.0 <3.0.0"
 
 
 dependencies:


### PR DESCRIPTION
After updating to Flutter 0.6 I now get dependency warnings that prevent me from using this package stating "version resolving failed" due to me running dart 2.1.x. Easy fix by increasing the pubspec.yaml environment to allow anything less than dart 3.0.0.